### PR TITLE
Add AKS Cluster Autoscaler Diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Truefoundry Azure Cluster Module
 
 | Name | Type |
 |------|------|
+| [azurerm_monitor_diagnostic_setting.cluster_autoscaler_diagnostic](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_role_assignment.network_contributor_cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Truefoundry Azure Cluster Module
 | <a name="input_intial_node_pool_instance_type"></a> [intial\_node\_pool\_instance\_type](#input\_intial\_node\_pool\_instance\_type) | Instance size of the initial node pool | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of the kubernetes engine | `string` | `"1.30"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location of the resource group | `string` | n/a | yes |
+| <a name="input_log_analytics_autoscaler_diagnostic_name"></a> [log\_analytics\_autoscaler\_diagnostic\_name](#input\_log\_analytics\_autoscaler\_diagnostic\_name) | Name of the log analytics workspace for autoscaler diagnostic | `string` | `"cluster-autoscaler-diagnostic"` | no |
 | <a name="input_log_analytics_workspace_enabled"></a> [log\_analytics\_workspace\_enabled](#input\_log\_analytics\_workspace\_enabled) | value to enable log analytics workspace | `bool` | `true` | no |
 | <a name="input_max_pods_per_node"></a> [max\_pods\_per\_node](#input\_max\_pods\_per\_node) | Max pods per node | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the cluster. If use\_existing\_cluster is enabled name is used to fetch details of existing cluster | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Truefoundry Azure Cluster Module
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | Allowed IP ranges to connect to the cluster | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
-| <a name="input_cluster_autoscaler_diagnostic_name_override"></a> [cluster\_autoscaler\_diagnostic\_name\_override](#input\_cluster\_autoscaler\_diagnostic\_name\_override) | Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic' | `string` | `""` | no |
+| <a name="input_cluster_autoscaler_diagnostic_enable_override"></a> [cluster\_autoscaler\_diagnostic\_enable\_override](#input\_cluster\_autoscaler\_diagnostic\_enable\_override) | Enable override of the cluster autoscaler diagnostic setting name. | `bool` | `false` | no |
+| <a name="input_cluster_autoscaler_diagnostic_override_name"></a> [cluster\_autoscaler\_diagnostic\_override\_name](#input\_cluster\_autoscaler\_diagnostic\_override\_name) | Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic' | `string` | `""` | no |
 | <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Whether the cluster is control plane | `bool` | n/a | yes |
 | <a name="input_control_plane_instance_type"></a> [control\_plane\_instance\_type](#input\_control\_plane\_instance\_type) | Whether the cluster is control plane | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_cpu_pools"></a> [cpu\_pools](#input\_cpu\_pools) | CPU pools to be attached | <pre>list(object({<br/>    name                  = string<br/>    instance_type         = string<br/>    min_count             = optional(number, 0)<br/>    max_count             = optional(number, 2)<br/>    enable_spot_pool      = optional(bool, true)<br/>    enable_on_demand_pool = optional(bool, true)<br/>  }))</pre> | n/a | yes |
@@ -55,8 +56,9 @@ Truefoundry Azure Cluster Module
 | <a name="input_intial_node_pool_instance_type"></a> [intial\_node\_pool\_instance\_type](#input\_intial\_node\_pool\_instance\_type) | Instance size of the initial node pool | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of the kubernetes engine | `string` | `"1.30"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location of the resource group | `string` | n/a | yes |
+| <a name="input_log_analytics_workspace_enable_override"></a> [log\_analytics\_workspace\_enable\_override](#input\_log\_analytics\_workspace\_enable\_override) | Enable override of the log analytics workspace name. | `bool` | `false` | no |
 | <a name="input_log_analytics_workspace_enabled"></a> [log\_analytics\_workspace\_enabled](#input\_log\_analytics\_workspace\_enabled) | value to enable log analytics workspace | `bool` | `true` | no |
-| <a name="input_log_analytics_workspace_name_override"></a> [log\_analytics\_workspace\_name\_override](#input\_log\_analytics\_workspace\_name\_override) | Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics' | `string` | `""` | no |
+| <a name="input_log_analytics_workspace_override_name"></a> [log\_analytics\_workspace\_override\_name](#input\_log\_analytics\_workspace\_override\_name) | Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics' | `string` | `""` | no |
 | <a name="input_max_pods_per_node"></a> [max\_pods\_per\_node](#input\_max\_pods\_per\_node) | Max pods per node | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the cluster. If use\_existing\_cluster is enabled name is used to fetch details of existing cluster | `string` | n/a | yes |
 | <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | Network plugin to use for cluster | `string` | `"kubenet"` | no |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Truefoundry Azure Cluster Module
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | Allowed IP ranges to connect to the cluster | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_cluster_autoscaler_diagnostic_name_override"></a> [cluster\_autoscaler\_diagnostic\_name\_override](#input\_cluster\_autoscaler\_diagnostic\_name\_override) | Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic' | `string` | `""` | no |
 | <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Whether the cluster is control plane | `bool` | n/a | yes |
 | <a name="input_control_plane_instance_type"></a> [control\_plane\_instance\_type](#input\_control\_plane\_instance\_type) | Whether the cluster is control plane | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_cpu_pools"></a> [cpu\_pools](#input\_cpu\_pools) | CPU pools to be attached | <pre>list(object({<br/>    name                  = string<br/>    instance_type         = string<br/>    min_count             = optional(number, 0)<br/>    max_count             = optional(number, 2)<br/>    enable_spot_pool      = optional(bool, true)<br/>    enable_on_demand_pool = optional(bool, true)<br/>  }))</pre> | n/a | yes |
@@ -54,8 +55,9 @@ Truefoundry Azure Cluster Module
 | <a name="input_intial_node_pool_instance_type"></a> [intial\_node\_pool\_instance\_type](#input\_intial\_node\_pool\_instance\_type) | Instance size of the initial node pool | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of the kubernetes engine | `string` | `"1.30"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location of the resource group | `string` | n/a | yes |
-| <a name="input_log_analytics_autoscaler_diagnostic_name"></a> [log\_analytics\_autoscaler\_diagnostic\_name](#input\_log\_analytics\_autoscaler\_diagnostic\_name) | Name of the log analytics workspace for autoscaler diagnostic | `string` | `"cluster-autoscaler-diagnostic"` | no |
 | <a name="input_log_analytics_workspace_enabled"></a> [log\_analytics\_workspace\_enabled](#input\_log\_analytics\_workspace\_enabled) | value to enable log analytics workspace | `bool` | `true` | no |
+| <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | Name of the log analytics workspace | `string` | `""` | no |
+| <a name="input_log_analytics_workspace_name_override"></a> [log\_analytics\_workspace\_name\_override](#input\_log\_analytics\_workspace\_name\_override) | Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics' | `string` | `""` | no |
 | <a name="input_max_pods_per_node"></a> [max\_pods\_per\_node](#input\_max\_pods\_per\_node) | Max pods per node | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the cluster. If use\_existing\_cluster is enabled name is used to fetch details of existing cluster | `string` | n/a | yes |
 | <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | Network plugin to use for cluster | `string` | `"kubenet"` | no |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Truefoundry Azure Cluster Module
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of the kubernetes engine | `string` | `"1.30"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location of the resource group | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_enabled"></a> [log\_analytics\_workspace\_enabled](#input\_log\_analytics\_workspace\_enabled) | value to enable log analytics workspace | `bool` | `true` | no |
-| <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | Name of the log analytics workspace | `string` | `""` | no |
 | <a name="input_log_analytics_workspace_name_override"></a> [log\_analytics\_workspace\_name\_override](#input\_log\_analytics\_workspace\_name\_override) | Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics' | `string` | `""` | no |
 | <a name="input_max_pods_per_node"></a> [max\_pods\_per\_node](#input\_max\_pods\_per\_node) | Max pods per node | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the cluster. If use\_existing\_cluster is enabled name is used to fetch details of existing cluster | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Truefoundry Azure Cluster Module
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | Allowed IP ranges to connect to the cluster | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
-| <a name="input_cluster_autoscaler_diagnostic_enable_override"></a> [cluster\_autoscaler\_diagnostic\_enable\_override](#input\_cluster\_autoscaler\_diagnostic\_enable\_override) | Enable override of the cluster autoscaler diagnostic setting name. | `bool` | `false` | no |
-| <a name="input_cluster_autoscaler_diagnostic_override_name"></a> [cluster\_autoscaler\_diagnostic\_override\_name](#input\_cluster\_autoscaler\_diagnostic\_override\_name) | Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic' | `string` | `""` | no |
+| <a name="input_cluster_autoscaler_diagnostic_enable_override"></a> [cluster\_autoscaler\_diagnostic\_enable\_override](#input\_cluster\_autoscaler\_diagnostic\_enable\_override) | Enable overriding of the cluster autoscaler diagnostic setting name. | `bool` | `false` | no |
+| <a name="input_cluster_autoscaler_diagnostic_override_name"></a> [cluster\_autoscaler\_diagnostic\_override\_name](#input\_cluster\_autoscaler\_diagnostic\_override\_name) | Cluster autoscaler diagnostic setting name. Default is '<cluster-name>-cluster-autoscaler' | `string` | `""` | no |
 | <a name="input_control_plane"></a> [control\_plane](#input\_control\_plane) | Whether the cluster is control plane | `bool` | n/a | yes |
 | <a name="input_control_plane_instance_type"></a> [control\_plane\_instance\_type](#input\_control\_plane\_instance\_type) | Whether the cluster is control plane | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_cpu_pools"></a> [cpu\_pools](#input\_cpu\_pools) | CPU pools to be attached | <pre>list(object({<br/>    name                  = string<br/>    instance_type         = string<br/>    min_count             = optional(number, 0)<br/>    max_count             = optional(number, 2)<br/>    enable_spot_pool      = optional(bool, true)<br/>    enable_on_demand_pool = optional(bool, true)<br/>  }))</pre> | n/a | yes |
@@ -56,9 +56,9 @@ Truefoundry Azure Cluster Module
 | <a name="input_intial_node_pool_instance_type"></a> [intial\_node\_pool\_instance\_type](#input\_intial\_node\_pool\_instance\_type) | Instance size of the initial node pool | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Version of the kubernetes engine | `string` | `"1.30"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location of the resource group | `string` | n/a | yes |
-| <a name="input_log_analytics_workspace_enable_override"></a> [log\_analytics\_workspace\_enable\_override](#input\_log\_analytics\_workspace\_enable\_override) | Enable override of the log analytics workspace name. | `bool` | `false` | no |
+| <a name="input_log_analytics_workspace_enable_override"></a> [log\_analytics\_workspace\_enable\_override](#input\_log\_analytics\_workspace\_enable\_override) | Enable overriding of the log analytics workspace name. | `bool` | `false` | no |
 | <a name="input_log_analytics_workspace_enabled"></a> [log\_analytics\_workspace\_enabled](#input\_log\_analytics\_workspace\_enabled) | value to enable log analytics workspace | `bool` | `true` | no |
-| <a name="input_log_analytics_workspace_override_name"></a> [log\_analytics\_workspace\_override\_name](#input\_log\_analytics\_workspace\_override\_name) | Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics' | `string` | `""` | no |
+| <a name="input_log_analytics_workspace_override_name"></a> [log\_analytics\_workspace\_override\_name](#input\_log\_analytics\_workspace\_override\_name) | Log analytics workspace name. Default is '<cluster-name>-log-analytics' | `string` | `""` | no |
 | <a name="input_max_pods_per_node"></a> [max\_pods\_per\_node](#input\_max\_pods\_per\_node) | Max pods per node | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the cluster. If use\_existing\_cluster is enabled name is used to fetch details of existing cluster | `string` | n/a | yes |
 | <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | Network plugin to use for cluster | `string` | `"kubenet"` | no |

--- a/aks.tf
+++ b/aks.tf
@@ -24,7 +24,7 @@ module "aks" {
   workload_identity_enabled   = var.workload_identity_enabled
   temporary_name_for_rotation = "tmpdefault"
 
-  log_analytics_workspace_enabled = var.log_analytics_workspace_enabled
+  log_analytics_workspace_enabled      = var.log_analytics_workspace_enabled
   cluster_log_analytics_workspace_name = local.log_analytics_workspace_name
   # agents_labels = {
   #   "truefoundry" : "essential"

--- a/aks.tf
+++ b/aks.tf
@@ -96,7 +96,7 @@ module "aks" {
 
 resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
   count              = var.log_analytics_workspace_enabled ? 1 : 0
-  name               = "cluster-autoscaler-diagnostic"
+  name               = var.log_analytics_autoscaler_diagnostic_name
   target_resource_id = module.aks[0].aks_id
 
   log_analytics_workspace_id     = module.aks[0].azurerm_log_analytics_workspace_id

--- a/aks.tf
+++ b/aks.tf
@@ -25,6 +25,7 @@ module "aks" {
   temporary_name_for_rotation = "tmpdefault"
 
   log_analytics_workspace_enabled = var.log_analytics_workspace_enabled
+  cluster_log_analytics_workspace_name = local.log_analytics_workspace_name
   # agents_labels = {
   #   "truefoundry" : "essential"
   # }
@@ -96,7 +97,7 @@ module "aks" {
 
 resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
   count              = var.log_analytics_workspace_enabled ? 1 : 0
-  name               = var.log_analytics_autoscaler_diagnostic_name
+  name               = local.log_analytics_cluster_autoscaler_diagnostic_name
   target_resource_id = module.aks[0].aks_id
 
   log_analytics_workspace_id     = module.aks[0].azurerm_log_analytics_workspace_id

--- a/aks.tf
+++ b/aks.tf
@@ -99,7 +99,7 @@ resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
   name               = "cluster-autoscaler-diagnostic"
   target_resource_id = module.aks[0].aks_id
 
-  log_analytics_workspace_id = module.aks[0].azurerm_log_analytics_workspace_id
+  log_analytics_workspace_id     = module.aks[0].azurerm_log_analytics_workspace_id
   log_analytics_destination_type = "Dedicated"
 
   enabled_log {

--- a/aks.tf
+++ b/aks.tf
@@ -93,3 +93,16 @@ module "aks" {
   sku_tier = var.sku_tier
   tags     = local.tags
 }
+
+resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
+  count              = var.log_analytics_workspace_enabled ? 1 : 0
+  name               = "cluster-autoscaler-diagnostic"
+  target_resource_id = module.aks[0].aks_id
+
+  log_analytics_workspace_id = module.aks[0].azurerm_log_analytics_workspace_id
+  log_analytics_destination_type = "Dedicated"
+
+  enabled_log {
+    category = "cluster-autoscaler"
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -118,6 +118,7 @@ locals {
       max_pods       = var.max_pods_per_node
   } } : null)
 
-  log_analytics_workspace_name                     = coalesce(var.log_analytics_workspace_name_override, "${var.name}-log-analytics")
-  log_analytics_cluster_autoscaler_diagnostic_name = coalesce(var.cluster_autoscaler_diagnostic_name_override, "${var.name}-cluster-autoscaler-diagnostic")
+  log_analytics_workspace_name = var.log_analytics_workspace_enable_override ? var.log_analytics_workspace_override_name : "${var.name}-log-analytics"
+
+  log_analytics_cluster_autoscaler_diagnostic_name = var.cluster_autoscaler_diagnostic_enable_override ? var.cluster_autoscaler_diagnostic_override_name : "${var.name}-cluster-autoscaler-diagnostic"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -118,6 +118,6 @@ locals {
       max_pods       = var.max_pods_per_node
   } } : null)
 
-  log_analytics_workspace_name = coalesce(var.log_analytics_workspace_name_override, "${var.name}-log-analytics")
+  log_analytics_workspace_name                     = coalesce(var.log_analytics_workspace_name_override, "${var.name}-log-analytics")
   log_analytics_cluster_autoscaler_diagnostic_name = coalesce(var.cluster_autoscaler_diagnostic_name_override, "${var.name}-cluster-autoscaler-diagnostic")
 }

--- a/locals.tf
+++ b/locals.tf
@@ -117,4 +117,7 @@ locals {
       vnet_subnet_id = var.subnet_id
       max_pods       = var.max_pods_per_node
   } } : null)
+
+  log_analytics_workspace_name = coalesce(var.log_analytics_workspace_name_override, "${var.name}-log-analytics")
+  log_analytics_cluster_autoscaler_diagnostic_name = coalesce(var.cluster_autoscaler_diagnostic_name_override, "${var.name}-cluster-autoscaler-diagnostic")
 }

--- a/locals.tf
+++ b/locals.tf
@@ -118,7 +118,7 @@ locals {
       max_pods       = var.max_pods_per_node
   } } : null)
 
-  log_analytics_workspace_name = var.log_analytics_workspace_enable_override ? var.log_analytics_workspace_override_name : "${var.name}-log-analytics"
+  log_analytics_workspace_name = var.log_analytics_workspace_enable_override ? var.log_analytics_workspace_override_name : substr("${var.name}-log-analytics", 0, 63)
 
-  log_analytics_cluster_autoscaler_diagnostic_name = var.cluster_autoscaler_diagnostic_enable_override ? var.cluster_autoscaler_diagnostic_override_name : "${var.name}-cluster-autoscaler-diagnostic"
+  log_analytics_cluster_autoscaler_diagnostic_name = var.cluster_autoscaler_diagnostic_enable_override ? var.cluster_autoscaler_diagnostic_override_name : substr("${var.name}-cluster-autoscaler", 0, 63)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,13 +35,13 @@ variable "log_analytics_workspace_enabled" {
 }
 
 variable "log_analytics_workspace_enable_override" {
-  description = "Enable override of the log analytics workspace name."
+  description = "Enable overriding of the log analytics workspace name."
   type        = bool
   default     = false
 }
 
 variable "log_analytics_workspace_override_name" {
-  description = "Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics'"
+  description = "Log analytics workspace name. Default is '<cluster-name>-log-analytics'"
   type        = string
   default     = ""
   validation {
@@ -51,13 +51,13 @@ variable "log_analytics_workspace_override_name" {
 }
 
 variable "cluster_autoscaler_diagnostic_enable_override" {
-  description = "Enable override of the cluster autoscaler diagnostic setting name."
+  description = "Enable overriding of the cluster autoscaler diagnostic setting name."
   type        = bool
   default     = false
 }
 
 variable "cluster_autoscaler_diagnostic_override_name" {
-  description = "Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic'"
+  description = "Cluster autoscaler diagnostic setting name. Default is '<cluster-name>-cluster-autoscaler'"
   type        = string
   default     = ""
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -34,10 +34,22 @@ variable "log_analytics_workspace_enabled" {
   default     = true
 }
 
-variable "log_analytics_autoscaler_diagnostic_name" {
-  description = "Name of the log analytics workspace for autoscaler diagnostic"
+variable "log_analytics_workspace_name" {
+  description = "Name of the log analytics workspace"
   type        = string
-  default     = "cluster-autoscaler-diagnostic"
+  default     = ""
+}
+
+variable "log_analytics_workspace_name_override" {
+  description = "Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics'"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_autoscaler_diagnostic_name_override" {
+  description = "Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic'"
+  type        = string
+  default     = ""
 }
 
 variable "oidc_issuer_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,16 +34,36 @@ variable "log_analytics_workspace_enabled" {
   default     = true
 }
 
-variable "log_analytics_workspace_name_override" {
+variable "log_analytics_workspace_enable_override" {
+  description = "Enable override of the log analytics workspace name."
+  type        = bool
+  default     = false
+}
+
+variable "log_analytics_workspace_override_name" {
   description = "Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics'"
   type        = string
   default     = ""
+  validation {
+    condition     = can(regex("^([a-zA-Z0-9][a-zA-Z0-9-]{2,61}[a-zA-Z0-9])?$", var.log_analytics_workspace_override_name))
+    error_message = "The workspace name must be 4-63 characters long, consisting of letters, digits, or '-', where '-' cannot be the first or last character."
+  }
 }
 
-variable "cluster_autoscaler_diagnostic_name_override" {
+variable "cluster_autoscaler_diagnostic_enable_override" {
+  description = "Enable override of the cluster autoscaler diagnostic setting name."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_autoscaler_diagnostic_override_name" {
   description = "Name override of the cluster autoscaler diagnostic setting. Default is '<cluster-name>-cluster-autoscaler-diagnostic'"
   type        = string
   default     = ""
+  validation {
+    condition     = can(regex("^([a-zA-Z0-9][a-zA-Z0-9-]{2,61}[a-zA-Z0-9])?$", var.cluster_autoscaler_diagnostic_override_name))
+    error_message = "The diagnostic setting name must be 4-63 characters long, consisting of letters, digits, or '-', where '-' cannot be the first or last character."
+  }
 }
 
 variable "oidc_issuer_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "log_analytics_workspace_enabled" {
   default     = true
 }
 
+variable "log_analytics_autoscaler_diagnostic_name" {
+  description = "Name of the log analytics workspace for autoscaler diagnostic"
+  type        = string
+  default     = "cluster-autoscaler-diagnostic"
+}
+
 variable "oidc_issuer_enabled" {
   description = "Enable OIDC for the cluster"
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -34,12 +34,6 @@ variable "log_analytics_workspace_enabled" {
   default     = true
 }
 
-variable "log_analytics_workspace_name" {
-  description = "Name of the log analytics workspace"
-  type        = string
-  default     = ""
-}
-
 variable "log_analytics_workspace_name_override" {
   description = "Name override of the log analytics workspace. Default is '<cluster-name>-log-analytics'"
   type        = string


### PR DESCRIPTION
This PR enables Diagnostic settings of Azure AKS and enabling the Cluster Autoscaler logs to be sent to the log analytics workspace