### PR TITLE
lifecycle-change-metric

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -108,6 +108,6 @@ resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
   }
 
   lifecycle {
-    ignore_changes = [ metric ]
+    ignore_changes = [metric]
   }
 }

--- a/aks.tf
+++ b/aks.tf
@@ -106,4 +106,8 @@ resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
   enabled_log {
     category = "cluster-autoscaler"
   }
+
+  lifecycle {
+    ignore_changes = [ metric ]
+  }
 }


### PR DESCRIPTION
Each plan gives the following diff
```
  # module.cluster.azurerm_monitor_diagnostic_setting.cluster_autoscaler_diagnostic[0] will be updated in-place
  ~ resource "azurerm_monitor_diagnostic_setting" "cluster_autoscaler_diagnostic" {
        id                             = "/subscriptions/dccd045a-3266-4358-8e95-64e6d7e41ea8/resourceGroups/ved-test-rg1/providers/Microsoft.ContainerService/managedClusters/example-aks-1|example-aks-1-cluster-autoscaler"
        name                           = "example-aks-1-cluster-autoscaler"
        # (5 unchanged attributes hidden)

      - metric {
          - category = "AllMetrics" -> null
          - enabled  = false -> null

          - retention_policy {
              - days    = 0 -> null
              - enabled = false -> null
            }
        }

        # (12 unchanged blocks hidden)
    }
```
Added lifecyle_changes to ignore metrics